### PR TITLE
setting contentType properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ AzureAdapter.prototype.uploadFile = function (file, callback) {
 			container,
 			blobName,
 			file.path, // original name
-			{ contentType: file.mimetype },
+			{ contentSettings: { contentType: file.mimetype } },
 			function (err, result) {
 				if (err) return callback(err);
 


### PR DESCRIPTION
contentType was not being set properly, it was falling back to application/octet-stream when checking the files in Azure Storage Explorer, which may cause some issues with some file types like images when you load them from the URL. contentType is part of contentSettings object.
https://docs.microsoft.com/en-us/javascript/api/azure-storage/azurestorage.services.blob.blobservice.blobservice.createblobrequestoptions?view=azure-node-latest#contentsettings